### PR TITLE
Double performance by use of lifetimes instead of locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -148,11 +148,8 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
@@ -281,6 +278,7 @@ name = "rayn"
 version = "0.1.0"
 dependencies = [
  "image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vek 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -302,7 +300,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -371,11 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "version_check"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "winapi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,7 +407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebdff791af04e30089bde8ad2a632b86af433b40c04db8d70ad4b21487db7a6a"
 "checksum inflate 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6f53b811ee8e2057ccf9643ca6b4277de90efaf5e61e55fd5254576926bb4245"
 "checksum jpeg-decoder 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b7d43206b34b3f94ea9445174bda196e772049b9bddbc620c9d29b2d20110d"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
@@ -442,7 +435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum vek 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "483b80cba8c10a65712105c34d36d880193284bfb9751f5014e56d195c988218"
-"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rayn"
 version = "0.1.0"
 license-file = "LICENSE.md"
 authors = ["Gray Olson <gray@grayolson.com>"]
+edition = "2018"
 
 [features]
 simd = []
@@ -12,3 +13,4 @@ vek = "0.9.4"
 image = "0.19"
 rand = "0.5.5"
 rayon = "1.0.2"
+lazy_static = "1.2.0"

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -17,6 +17,6 @@ impl Camera {
     }
 
     pub fn get_ray(&self, uv: Vec3) -> Ray {
-        Ray::new(self.origin.clone(), self.lower_left + self.full_size * uv)
+        Ray::new(self.origin, self.lower_left + self.full_size * uv)
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,5 +1,5 @@
-use math::Vec3;
-use ray::Ray;
+use crate::math::Vec3;
+use crate::ray::Ray;
 
 pub struct Camera {
     lower_left: Vec3,

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,5 +1,5 @@
+use crate::math::Vec3;
 use image;
-use math::Vec3;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Color(pub Vec3);

--- a/src/hitable.rs
+++ b/src/hitable.rs
@@ -1,19 +1,17 @@
-use std::sync::Arc;
-
-use material::Material;
-use math::Vec3;
-use ray::Ray;
+use crate::material::Material;
+use crate::math::Vec3;
+use crate::ray::Ray;
 
 #[derive(Clone)]
-pub struct HitRecord {
+pub struct HitRecord<'a> {
     pub t: f32,
     pub p: Vec3,
     pub n: Vec3,
-    pub material: Arc<Material>,
+    pub material: &'a Material,
 }
 
-impl HitRecord {
-    pub fn new(t: f32, p: Vec3, n: Vec3, material: Arc<Material>) -> Self {
+impl<'a> HitRecord<'a> {
+    pub fn new(t: f32, p: Vec3, n: Vec3, material: &'a Material) -> Self {
         HitRecord { t, p, n, material }
     }
 }
@@ -60,7 +58,8 @@ impl Hitable for HitableList {
                 }
                 let hr = if hr.is_some() { hr } else { acc.0 };
                 (hr, closest)
-            }).0;
+            })
+            .0;
         ret
     }
 }

--- a/src/hitable.rs
+++ b/src/hitable.rs
@@ -42,24 +42,16 @@ impl ::std::ops::Deref for HitableList {
 
 impl Hitable for HitableList {
     fn hit(&self, ray: &Ray, t_range: ::std::ops::Range<f32>) -> Option<HitRecord> {
-        let ret = self
-            .iter()
+        self.iter()
             .fold((None, t_range.end), |acc, hitable| {
                 let mut closest = acc.1;
                 let hr = hitable.hit(ray, t_range.start..closest);
-                if let Some(HitRecord {
-                    t,
-                    p: _,
-                    n: _,
-                    material: _,
-                }) = hr
-                {
+                if let Some(HitRecord { t, .. }) = hr {
                     closest = t;
                 }
                 let hr = if hr.is_some() { hr } else { acc.0 };
                 (hr, closest)
             })
-            .0;
-        ret
+            .0
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,6 @@
-extern crate image;
-extern crate rand;
-extern crate rayon;
-extern crate vek;
-
-use std::time::Instant;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use std::time::Instant;
 
 use rand::distributions::Uniform;
 use rand::prelude::*;
@@ -19,26 +14,79 @@ mod math;
 mod ray;
 mod sphere;
 
-use camera::Camera;
-use color::Color;
-use hitable::{Hitable, HitableList};
-use material::{Diffuse, Material, Metal, Refractive};
-use math::Vec3;
-use ray::Ray;
-use sphere::Sphere;
+use crate::camera::Camera;
+use crate::color::Color;
+use crate::hitable::{Hitable, HitableList};
+use crate::material::{Diffuse, Metal, Refractive};
+use crate::math::Vec3;
+use crate::ray::Ray;
+use crate::sphere::Sphere;
+
+use lazy_static::lazy_static;
+lazy_static! {
+    static ref pink_diffuse: Diffuse = Diffuse::new(Color::new(0.7, 0.3, 0.4), 0.0);
+    static ref ground: Diffuse = Diffuse::new(Color::new(0.35, 0.3, 0.45), 0.2);
+    static ref gold: Metal = Metal::new(Color::new(1.0, 0.9, 0.5), 0.0);
+    static ref gold_rough: Metal = Metal::new(Color::new(1.0, 0.9, 0.5), 0.2);
+    static ref silver: Metal = Metal::new(Color::new(0.9, 0.9, 0.9), 0.05);
+    static ref glass: Refractive = Refractive::new(Color::new(0.9, 0.9, 0.9), 0.0, 1.5);
+    static ref glass_rough: Refractive = Refractive::new(Color::new(0.9, 0.9, 0.9), 0.2, 1.5);
+    static ref WORLD: HitableList = {
+        let mut world = HitableList::new();
+        world.push(Box::new(Sphere::new(
+            Vec3::new(0.0, -200.5, -1.0),
+            200.0,
+            &*ground,
+        )));
+        world.push(Box::new(Sphere::new(
+            Vec3::new(0.0, 0.0, -1.0),
+            0.5,
+            &*silver,
+        )));
+        world.push(Box::new(Sphere::new(
+            Vec3::new(-1.0, 0.0, -1.0),
+            0.5,
+            &*pink_diffuse,
+        )));
+        world.push(Box::new(Sphere::new(
+            Vec3::new(1.0, -0.25, -1.0),
+            0.25,
+            &*gold,
+        )));
+        world.push(Box::new(Sphere::new(
+            Vec3::new(0.4, -0.375, -0.5),
+            0.125,
+            &*glass,
+        )));
+        world.push(Box::new(Sphere::new(
+            Vec3::new(0.2, -0.4, -0.35),
+            0.1,
+            &*glass,
+        )));
+        world.push(Box::new(Sphere::new(
+            Vec3::new(-0.25, -0.375, -0.15),
+            0.125,
+            &*glass_rough,
+        )));
+        world.push(Box::new(Sphere::new(
+            Vec3::new(-0.5, -0.375, -0.5),
+            0.125,
+            &*gold_rough,
+        )));
+        world
+    };
+}
 
 const DIMS: (u32, u32) = (1920, 1080);
-const SAMPLES: usize = 2048;
-const MAX_BOUNCES: usize = 50;
+const SAMPLES: usize = 128;
+const MAX_BOUNCES: usize = 256;
 
-fn compute_color(ray: &Ray, hitables: Arc<RwLock<HitableList>>, bounces: usize) -> Color {
-    let ht = &hitables.read().unwrap();
+fn compute_color(ray: &Ray, bounces: usize) -> Color {
     if bounces < MAX_BOUNCES {
-        if let Some(record) = ht.hit(ray, 0.001..1000.0) {
+        if let Some(record) = WORLD.hit(ray, 0.001..1000.0) {
             let scatter = record.material.scatter(ray, &record.n);
             if let Some((attenuation, bounce)) = scatter {
-                compute_color(&Ray::new(record.p, bounce), hitables.clone(), bounces + 1)
-                    * attenuation
+                compute_color(&Ray::new(record.p, bounce), bounces + 1) * attenuation
             } else {
                 Color::zero()
             }
@@ -57,58 +105,6 @@ fn main() {
     let mut img = image::RgbImage::new(DIMS.0, DIMS.1);
 
     let camera = Arc::new(Camera::new(DIMS.0 as f32 / DIMS.1 as f32));
-
-    let pink_diffuse: Arc<Material> = Arc::new(Diffuse::new(Color::new(0.7, 0.3, 0.4), 0.0));
-    let ground: Arc<Material> = Arc::new(Diffuse::new(Color::new(0.35, 0.3, 0.45), 0.2));
-    let gold: Arc<Material> = Arc::new(Metal::new(Color::new(1.0, 0.9, 0.5), 0.0));
-    let gold_rough: Arc<Material> = Arc::new(Metal::new(Color::new(1.0, 0.9, 0.5), 0.2));
-    let silver: Arc<Material> = Arc::new(Metal::new(Color::new(0.9, 0.9, 0.9), 0.05));
-    let glass: Arc<Material> = Arc::new(Refractive::new(Color::new(0.9, 0.9, 0.9), 0.0, 1.5));
-    let glass_rough: Arc<Material> = Arc::new(Refractive::new(Color::new(0.9, 0.9, 0.9), 0.2, 1.5));
-
-    let mut world = HitableList::new();
-    world.push(Box::new(Sphere::new(
-        Vec3::new(0.0, -200.5, -1.0),
-        200.0,
-        Arc::clone(&ground),
-    )));
-    world.push(Box::new(Sphere::new(
-        Vec3::new(0.0, 0.0, -1.0),
-        0.5,
-        Arc::clone(&silver),
-    )));
-    world.push(Box::new(Sphere::new(
-        Vec3::new(-1.0, 0.0, -1.0),
-        0.5,
-        Arc::clone(&pink_diffuse),
-    )));
-    world.push(Box::new(Sphere::new(
-        Vec3::new(1.0, -0.25, -1.0),
-        0.25,
-        Arc::clone(&gold),
-    )));
-    world.push(Box::new(Sphere::new(
-        Vec3::new(0.4, -0.375, -0.5),
-        0.125,
-        Arc::clone(&glass),
-    )));
-    world.push(Box::new(Sphere::new(
-        Vec3::new(0.2, -0.4, -0.35),
-        0.1,
-        Arc::clone(&glass),
-    )));
-    world.push(Box::new(Sphere::new(
-        Vec3::new(-0.25, -0.375, -0.15),
-        0.125,
-        Arc::clone(&glass_rough),
-    )));
-    world.push(Box::new(Sphere::new(
-        Vec3::new(-0.5, -0.375, -0.5),
-        0.125,
-        Arc::clone(&gold_rough),
-    )));
-
-    let world = Arc::new(RwLock::new(world));
 
     let mut pixels = vec![Color::zero(); DIMS.0 as usize * DIMS.1 as usize];
 
@@ -131,8 +127,9 @@ fn main() {
                 );
                 // let uv = Vec3::new(x as f32 / DIMS.0 as f32, y as f32 / DIMS.1 as f32, 0.0);
                 let ray = camera.clone().get_ray(uv);
-                compute_color(&ray, world.clone(), 0)
-            }).fold(Color::zero(), |a, b| a + b);
+                compute_color(&ray, 0)
+            })
+            .fold(Color::zero(), |a, b| a + b);
         let col = col / SAMPLES as f32;
         *p = col;
         if i % 100000 == 0 {
@@ -153,7 +150,10 @@ fn main() {
     let time_secs = time.as_secs();
     let time_millis = time.subsec_millis();
 
-    println!("Done in {} seconds.", time_secs as f32 + time_millis as f32 / 1000.0);
+    println!(
+        "Done in {} seconds.",
+        time_secs as f32 + time_millis as f32 / 1000.0
+    );
 
     img.save("render_working.png").unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,6 @@ fn main() {
         let x = i % DIMS.0 as usize;
         let y = (i - x) / DIMS.0 as usize;
         let col = (0..SAMPLES)
-            .into_iter()
             .map(|_| {
                 let mut rng = thread_rng();
                 let uniform = Uniform::new(0.0, 1.0);
@@ -132,11 +131,11 @@ fn main() {
             .fold(Color::zero(), |a, b| a + b);
         let col = col / SAMPLES as f32;
         *p = col;
-        if i % 100000 == 0 {
+        if i % 100_000 == 0 {
             let n = mutated.fetch_add(1, Ordering::Relaxed);
             println!(
                 "{}% finished...",
-                n as f32 / (DIMS.0 * DIMS.1) as f32 * 100.0 * 100000.0
+                n as f32 / (DIMS.0 * DIMS.1) as f32 * 100.0 * 100_000.0
             );
         }
     });
@@ -154,7 +153,7 @@ fn main() {
         "Done in {} seconds.",
         time_secs as f32 + time_millis as f32 / 1000.0
     );
-    let args: Vec<String> = std::env::args().into_iter().collect();
+    let args: Vec<String> = std::env::args().collect();
     let default = String::from("render.png");
     let filename = args.get(1).unwrap_or(&default);
     println!("Saving to {}", filename);

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,10 @@ fn main() {
         "Done in {} seconds.",
         time_secs as f32 + time_millis as f32 / 1000.0
     );
+    let args: Vec<String> = std::env::args().into_iter().collect();
+    let default = String::from("render.png");
+    let filename = args.get(1).unwrap_or(&default);
+    println!("Saving to {}", filename);
 
-    img.save("render_working.png").unwrap();
+    img.save(filename).unwrap();
 }

--- a/src/material.rs
+++ b/src/material.rs
@@ -21,14 +21,14 @@ impl Diffuse {
 
 impl Material for Diffuse {
     fn scatter(&self, ray: &Ray, norm: &Vec3) -> Option<(Color, Vec3)> {
-        let norm = norm.clone();
+        let norm = *norm;
         let cos = saturate(norm.normalized().dot(ray.dir().clone().normalized() * -1.0));
         // println!("{}", cos);
         let fresnel = f_schlick(cos, 0.04);
         let bounce = if thread_rng().gen::<f32>() > fresnel {
             norm + Vec3::rand(&mut thread_rng())
         } else {
-            ray.dir().reflected(norm.clone()) + (Vec3::rand(&mut thread_rng()) * self.roughness)
+            ray.dir().reflected(norm) + (Vec3::rand(&mut thread_rng()) * self.roughness)
         };
         Some((self.albedo, bounce))
     }
@@ -70,16 +70,16 @@ impl Refractive {
 
 impl Material for Refractive {
     fn scatter(&self, ray: &Ray, norm: &Vec3) -> Option<(Color, Vec3)> {
-        let norm = norm.clone();
+        let norm = *norm;
         let (refract_norm, eta, cos) = if ray.dir().dot(norm) > 0.0 {
             (
-                norm.clone() * -1.0,
+                norm * -1.0,
                 self.ior,
                 norm.normalized().dot(ray.dir().clone().normalized()),
             )
         } else {
             (
-                norm.clone(),
+                norm,
                 1.0 / self.ior,
                 -norm.normalized().dot(ray.dir().clone().normalized()),
             )

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,8 +1,8 @@
 use rand::prelude::*;
 
-use color::Color;
-use math::{f0_from_ior, f_schlick, f_schlick_c, saturate, RandomInit, Vec3};
-use ray::Ray;
+use crate::color::Color;
+use crate::math::{f0_from_ior, f_schlick, f_schlick_c, saturate, RandomInit, Vec3};
+use crate::ray::Ray;
 
 pub trait Material: Send + Sync {
     fn scatter(&self, ray: &Ray, norm: &Vec3) -> Option<(Color, Vec3)>;

--- a/src/math.rs
+++ b/src/math.rs
@@ -3,7 +3,7 @@ use std::f32::consts::PI;
 use rand::prelude::*;
 use vek::vec;
 
-use color::Color;
+use crate::color::Color;
 
 #[cfg(features = "simd")]
 pub type Vec3 = vec::repr_simd::Vec3<f32>;

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -1,4 +1,4 @@
-use math::Vec3;
+use crate::math::Vec3;
 
 pub struct Ray {
     orig: Vec3,

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -1,18 +1,16 @@
-use std::sync::Arc;
+use crate::hitable::{HitRecord, Hitable};
+use crate::material::Material;
+use crate::math::Vec3;
+use crate::ray::Ray;
 
-use hitable::{HitRecord, Hitable};
-use material::Material;
-use math::Vec3;
-use ray::Ray;
-
-pub struct Sphere {
+pub struct Sphere<'a> {
     orig: Vec3,
     rad: f32,
-    material: Arc<Material>,
+    material: &'a Material,
 }
 
-impl Sphere {
-    pub fn new(orig: Vec3, rad: f32, material: Arc<Material>) -> Self {
+impl<'a> Sphere<'a> {
+    pub fn new(orig: Vec3, rad: f32, material: &'a impl Material) -> Self {
         Sphere {
             orig,
             rad,
@@ -24,7 +22,7 @@ impl Sphere {
     }
 }
 
-impl Hitable for Sphere {
+impl<'a> Hitable for Sphere<'a> {
     fn hit(&self, ray: &Ray, t_range: ::std::ops::Range<f32>) -> Option<HitRecord> {
         let oc = ray.orig() - self.orig;
         let a = ray.dir().dot(ray.dir().clone());
@@ -39,14 +37,14 @@ impl Hitable for Sphere {
                 let p = ray.point_at(t);
                 let mut n = p - self.orig();
                 n /= self.rad;
-                return Some(HitRecord::new(t, p, n, Arc::clone(&self.material)));
+                return Some(HitRecord::new(t, p, n, self.material));
             }
             let t = (-b + desc_sqrt) / (2.0 * a);
             if t > t_range.start && t < t_range.end {
                 let p = ray.point_at(t);
                 let mut n = p - self.orig();
                 n /= self.rad;
-                return Some(HitRecord::new(t, p, n, Arc::clone(&self.material)));
+                return Some(HitRecord::new(t, p, n, self.material));
             }
         }
         None

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -26,25 +26,25 @@ impl<'a> Hitable for Sphere<'a> {
     fn hit(&self, ray: &Ray, t_range: ::std::ops::Range<f32>) -> Option<HitRecord> {
         let oc = ray.orig() - self.orig;
         let a = ray.dir().dot(ray.dir().clone());
-        let b = 2.0 * oc.clone().dot(ray.dir().clone());
-        let c = oc.clone().dot(oc) - self.rad * self.rad;
+        let b = 2.0 * oc.dot(ray.dir().clone());
+        let c = oc.dot(oc) - self.rad * self.rad;
         let descrim = b * b - 4.0 * a * c;
 
         if descrim >= 0.0 {
             let desc_sqrt = descrim.sqrt();
             let t = (-b - desc_sqrt) / (2.0 * a);
             if t > t_range.start && t < t_range.end {
-                let p = ray.point_at(t);
-                let mut n = p - self.orig();
-                n /= self.rad;
-                return Some(HitRecord::new(t, p, n, self.material));
+                let point = ray.point_at(t);
+                let mut offset = point - self.orig();
+                offset /= self.rad;
+                return Some(HitRecord::new(t, point, offset, self.material));
             }
             let t = (-b + desc_sqrt) / (2.0 * a);
             if t > t_range.start && t < t_range.end {
-                let p = ray.point_at(t);
-                let mut n = p - self.orig();
-                n /= self.rad;
-                return Some(HitRecord::new(t, p, n, self.material));
+                let point = ray.point_at(t);
+                let mut offset = point - self.orig();
+                offset /= self.rad;
+                return Some(HitRecord::new(t, point, offset, self.material));
             }
         }
         None


### PR DESCRIPTION
Global state can be shared safely without locks iff it's not mutable, so, we take advantage of this fact. World has been extracted to a lazy_static, and performance has doubled (likely more than double with more cores)