### PR TITLE
Update generic-array to 0.14 to avoid UB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,11 +144,12 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "generic-array"
-version = "0.13.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -630,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "ultraviolet"
@@ -648,6 +649,12 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ minterpolate = { version = "0.4", optional = true }
 splines = { version = "2.0", optional = true }
 sdfu = { version = "0.3", features = ["ultraviolet"] }
 num_cpus = "1.10"
-generic-array = "0.13"
+generic-array = "0.14"
 bumpalo = { version = "3.4", features = ["collections"] }
 # ultraviolet = { path = "../ultraviolet" }
 ultraviolet = "0.4"


### PR DESCRIPTION
`generic-array` `0.13`  has some undefined behaviour: https://github.com/fizyk20/generic-array/issues/89 which for me results in getting this error:

`thread 'main' panicked at 'attempted to leave type 'generic_array::GenericArray<film::ChannelStorage, generic_array::typenum::UInt<generic_array::typenum::UInt<generic_array::typenum::UInt<generic_array::typenum::UTerm, generic_array::typenum::B1>, generic_array::typenum::B0>, generic_array::typenum::B0>>' uninitialized, which is invalid', /rustc/cb75ad5db02783e8b0222fee363c5f63f7e2cf5b/library/core/src/mem/mod.rs:659:9`

This PR fixes that and now I can run `rayn` properly :D